### PR TITLE
refactor: add matplotlibrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,7 @@ RUN echo "export PATH=${PATH}" >> ~/.zshrc
 # set font
 COPY ./fonts/* /usr/share/fonts/SourceHanSans/
 
+# set matplotlibrc
+COPY ./matplotlib/* ${HOME}/.config/matplotlib/
+
 CMD ["/bin/zsh"]

--- a/matplotlib/matplotlibrc
+++ b/matplotlib/matplotlibrc
@@ -1,0 +1,29 @@
+font.sans-serif: Source Han Sans SC
+
+# https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/mpl-data/stylelib/dark_background.mplstyle
+# Set black background default line colors to white.
+
+lines.color: white
+patch.edgecolor: white
+
+text.color: white
+
+axes.facecolor: black
+axes.edgecolor: white
+axes.labelcolor: white
+axes.prop_cycle: cycler('color', ['8dd3c7', 'feffb3', 'bfbbd9', 'fa8174', '81b1d2', 'fdb462', 'b3de69', 'bc82bd', 'ccebc4', 'ffed6f'])
+
+xtick.color: white
+ytick.color: white
+
+grid.color: white
+
+figure.facecolor: black
+figure.edgecolor: black
+
+### Boxplots
+boxplot.boxprops.color: white
+boxplot.capprops.color: white
+boxplot.flierprops.color: white
+boxplot.flierprops.markeredgecolor: white
+boxplot.whiskerprops.color: white


### PR DESCRIPTION
目前因为 python-executor 会复用进程，matplotlibrc 之类全局配置要重新启动项目才能生效。后面 @leavesster 会改成按 session 启动 python 进程，就没有这个问题了。